### PR TITLE
fix: replace npm install with pnpm install in changeset version script

### DIFF
--- a/.github/changeset-version.js
+++ b/.github/changeset-version.js
@@ -7,4 +7,4 @@ import { execSync } from "child_process"
 // This is a workaround until this is handled automatically by `changeset version`.
 // See https://github.com/changesets/changesets/issues/421.
 execSync("npx changeset version", { stdio: "inherit" })
-execSync("npm install", { stdio: "inherit" })
+execSync("pnpm install", { stdio: "inherit" })


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the
      [contributing guide](https://github.com/SlickYeet/create-lx2-app/blob/main/CONTRIBUTING.md)
      (updated 2025-03-27).
- [x] The PR title follows the convention we established
      [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)

---

## Changelog

- replace npm install with pnpm install in changeset version script [f798e82](https://github.com/SlickYeet/create-lx2-app/commit/f798e82e7ab81b91dc8b66b3c1830f30ea11db51)