### PR TITLE
fix(cli): update help screen to listing all possible frameworks

### DIFF
--- a/.changeset/every-rings-jam.md
+++ b/.changeset/every-rings-jam.md
@@ -1,0 +1,5 @@
+---
+"create-lx2-app": patch
+---
+
+fix help screen not listing all possible frameworks

--- a/cli/src/core/index.ts
+++ b/cli/src/core/index.ts
@@ -4,6 +4,7 @@ import { Command } from "commander"
 import { CREATE_LX2_APP, DEFAULT_APP_NAME } from "@/constants.js"
 import {
   authProviders,
+  backendFrameworks,
   databaseORM,
   databaseProviders,
   type AuthProvider,
@@ -105,7 +106,7 @@ export async function runCli(): Promise<CliResults> {
     /** @experimental - Used for CI E2E tests. Used in conjunction with `--CI` to skip prompting. */
     .option(
       "--backend [framework]",
-      `Choose a backend framework to use. Possible values: ${defaultOptions.flags.backend}`,
+      `Choose a backend framework to use. Possible values: ${backendFrameworks.join(", ")}`,
       defaultOptions.flags.backend
     )
     /** @experimental Used for CI E2E tests. Used in conjunction with `--CI` to skip prompting. */


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the
      [contributing guide](https://github.com/SlickYeet/create-lx2-app/blob/main/CONTRIBUTING.md)
      (updated 2025-03-27).
- [x] The PR title follows the convention we established
      [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)

---

## Changelog

- update backend option help text to include all possible frameworks [1bdd413](https://github.com/SlickYeet/create-lx2-app/commit/1bdd41336e4f4af381147563b29ec4c98aa6ae71)
- add changeset [4343251](https://github.com/SlickYeet/create-lx2-app/commit/43432511d760fc3e0ad465e25e2fb021d33fed1a)