### PR TITLE
fix(CI): update artifact path for npm package upload

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -43,4 +43,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: npm-package-create-lx2-app@${{ steps.package-version.outputs.current-version }}-pr-${{ github.event.number }} # encode the PR number into the artifact name
-          path: packages/shadcn/dist/index.js
+          path: cli/dist/index.js


### PR DESCRIPTION
Closes #187 

## ✅ Checklist

- [x] I have followed every step in the
      [contributing guide](https://github.com/SlickYeet/create-lx2-app/blob/main/CONTRIBUTING.md)
      (updated 2025-03-27).
- [x] The PR title follows the convention we established
      [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)

---

## Changelog

- update artifact path for npm package upload in prerelease workflow [d716a46](https://github.com/SlickYeet/create-lx2-app/commit/d716a46bc2d7f94112ebe6fc9473e1075f73afd0)
