### PR TITLE
fix: update prerelease comment workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,6 @@ jobs:
 
       - run: pnpm typecheck
 
-
   build-docs:
     runs-on: ubuntu-latest
     name: Build and Check Docs

--- a/.github/workflows/prerelease-comment.yml
+++ b/.github/workflows/prerelease-comment.yml
@@ -53,13 +53,13 @@ jobs:
             ```
 
       - name: "Remove the autorelease label once published"
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             github.rest.issues.removeLabel({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: '${{ env.WORKFLOW_RUN_PR }}',
+              issue_number: ${{ env.WORKFLOW_RUN_PR }},
               name: '🚀 autorelease',
             });

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -7,6 +7,7 @@ on:
     types: [labeled]
     branches:
       - main
+
 jobs:
   prerelease:
     if: |


### PR DESCRIPTION
Closes #175 

## ✅ Checklist

- [x] I have followed every step in the
      [contributing guide](https://github.com/SlickYeet/create-lx2-app/blob/main/CONTRIBUTING.md)
      (updated 2025-03-27).
- [x] The PR title follows the convention we established
      [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)

---

## Changelog

- update prerelease comment workflow [92309ae](https://github.com/SlickYeet/create-lx2-app/commit/92309ae252adc63c05c1a91459c5f5af488cf591)
