### PR TITLE
fix(cli): remove `--turbopack` from dev and build scripts

### DIFF
--- a/.changeset/dull-toys-play.md
+++ b/.changeset/dull-toys-play.md
@@ -1,0 +1,5 @@
+---
+"create-lx2-app": patch
+---
+
+Remove `--turbopack` from build and dev scripts

--- a/cli/template/base/package.json
+++ b/cli/template/base/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "next dev --turbopack",
-    "build": "next build --turbopack",
+    "dev": "next dev",
+    "build": "next build",
     "start": "next start"
   },
   "dependencies": {


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the
      [contributing guide](https://github.com/SlickYeet/create-lx2-app/blob/main/CONTRIBUTING.md)
      (updated 2025-03-27).
- [x] The PR title follows the convention we established
      [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)

---

## Changelog

- remove `--turbopack` from dev and build scripts [13a45e7](https://github.com/SlickYeet/create-lx2-app/commit/13a45e7f2bd0ef1deee2e10a96e8ffb05cea37d8)
