### PR TITLE
fix(cli): replace `pnpm dlx` with `npx` in auth scripts

### DIFF
--- a/.changeset/vast-parrots-boil.md
+++ b/.changeset/vast-parrots-boil.md
@@ -1,0 +1,5 @@
+---
+"create-lx2-app": patch
+---
+
+Replace `pnpm dlx` with `npx` in better-auth installer script

--- a/cli/src/installers/better-auth.ts
+++ b/cli/src/installers/better-auth.ts
@@ -77,11 +77,11 @@ export const betterAuthInstaller: Installer = ({
     projectDir,
     scripts: {
       "auth:generate":
-        "pnpm dlx @better-auth/cli@latest generate --config ./src/server/auth/index.ts --yes",
+        "npx @better-auth/cli@latest generate --config ./src/server/auth/index.ts --yes",
       ...(!usingPrisma &&
         !usingDrizzle && {
           "auth:migrate":
-            "pnpm dlx @better-auth/cli@latest migrate --config ./src/server/auth/index.ts --yes",
+            "npx @better-auth/cli@latest migrate --config ./src/server/auth/index.ts --yes",
         }),
     },
   })


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the
      [contributing guide](https://github.com/SlickYeet/create-lx2-app/blob/main/CONTRIBUTING.md)
      (updated 2025-03-27).
- [x] The PR title follows the convention we established
      [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)

---

## Changelog

- replace pnpm dlx with npx in auth scripts [32090e7](https://github.com/SlickYeet/create-lx2-app/commit/32090e75cc159da4020c4c48b0ff8589eb22c01d)