### PR TITLE
fix(cli): duplicate NEXT_PUBLIC_URL

### DIFF
--- a/.changeset/free-places-taste.md
+++ b/.changeset/free-places-taste.md
@@ -1,0 +1,6 @@
+---
+"create-lx2-app": patch
+---
+
+fix: project scaffolding with duplicate NEXT_PUBLIC_URL when using trpc and
+better-auth

--- a/cli/src/installers/env-vars.ts
+++ b/cli/src/installers/env-vars.ts
@@ -197,7 +197,6 @@ DISCORD_CLIENT_SECRET=""
 # You can generate a new secret by going to the Better Auth docs:
 # https://www.better-auth.com/docs/installation#set-environment-variables
 BETTER_AUTH_SECRET=""
-NEXT_PUBLIC_URL="http://localhost:3000" # Base URL of your app
 
 # Better Auth Discord Provider
 DISCORD_CLIENT_ID=""
@@ -213,9 +212,9 @@ DISCORD_CLIENT_SECRET=""
 `
   }
 
-  if (usingTRPC)
+  if (usingTRPC || usingBetterAuth)
     content += `
-NEXT_PUBLIC_URL="http://localhost:3000"
+NEXT_PUBLIC_URL="http://localhost:3000" # Base URL of your app
 `
 
   return content


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the
      [contributing guide](https://github.com/SlickYeet/create-lx2-app/blob/main/CONTRIBUTING.md)
      (updated 2025-03-27).
- [x] The PR title follows the convention we established
      [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)

---

## Changelog

- [bdb9c07](https://github.com/lx2dev/create-lx2-app/commit/bdb9c07375daec0fde7b772e80bae2f23229eca7) fix duplicate NEXT_PUBLIC_URL in projects scaffolding with TRPC and Better Auth